### PR TITLE
emscripten: enable loop delay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -257,7 +257,7 @@ COPY --link --from=assets /patches/tinyemu /tinyemu
 WORKDIR /tinyemu
 RUN make -j $(nproc) -f Makefile \
     CONFIG_FS_NET= CONFIG_SDL= CONFIG_INT128= CONFIG_X86EMU= CONFIG_SLIRP= \
-    CC="emcc --embed-file /pack -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s INITIAL_MEMORY=${EMSCRIPTEN_INITIAL_MEMORY} -UEMSCRIPTEN -sNO_EXIT_RUNTIME=1 -sFORCE_FILESYSTEM=1" && \
+    CC="emcc --embed-file /pack -s WASM=1 -s ASYNCIFY=1 -s ALLOW_MEMORY_GROWTH=1 -s INITIAL_MEMORY=${EMSCRIPTEN_INITIAL_MEMORY} -UEMSCRIPTEN -DON_BROWSER -sNO_EXIT_RUNTIME=1 -sFORCE_FILESYSTEM=1" && \
     mkdir -p /out/ && mv temu /out/container.js && mv temu.wasm /out/
 
 FROM scratch AS js

--- a/patches/tinyemu/temu.c
+++ b/patches/tinyemu/temu.c
@@ -58,6 +58,10 @@
 #include "wasi.h"
 #endif
 
+#ifdef ON_BROWSER
+#include <emscripten.h>
+#endif
+
 #ifndef _WIN32
 
 typedef struct {
@@ -620,6 +624,11 @@ void virt_machine_run(VirtMachine *m, int enable_stdin)
 #endif
     tv.tv_sec = delay / 1000;
     tv.tv_usec = (delay % 1000) * 1000;
+#ifdef ON_BROWSER
+    // no timeout; TODO: remove this when sleep supports timeout
+    tv.tv_sec = 0;
+    tv.tv_usec = 0;
+#endif
     if (enable_stdin && init_done)
         ret = select(fd_max + 1, &rfds, &wfds, NULL, &tv);
     if (m->net) {
@@ -645,6 +654,9 @@ void virt_machine_run(VirtMachine *m, int enable_stdin)
     sdl_refresh(m);
 #endif
     
+#ifdef ON_BROWSER
+    emscripten_sleep(delay);
+#endif
     virt_machine_interp(m, MAX_EXEC_CYCLE);
 }
 


### PR DESCRIPTION
`select` doesn't seem to implement `timeout` so the current implementation results in busy main loop without sleep. Here we introduce the delay using [emscripten_sleep](https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_sleep) provided by Asyncify.
