### PR TITLE
emscripten: allow specifying filename

### DIFF
--- a/examples/emscripten/htdocs/worker.js
+++ b/examples/emscripten/htdocs/worker.js
@@ -1,7 +1,7 @@
 importScripts("https://cdn.jsdelivr.net/npm/xterm-pty@0.9.4/workerTools.js");
 
 onmessage = (msg) => {
-  importScripts(location.origin + "/container.js");
+  importScripts(location.origin + "/out.js");
 
   emscriptenHack(new TtyClient(msg.data));
 };

--- a/patches/tinyemu/Makefile
+++ b/patches/tinyemu/Makefile
@@ -103,8 +103,10 @@ CFLAGS+=-DCONFIG_X86EMU
 EMU_OBJS+=x86_cpu.o x86_machine.o ide.o ps2.o vmmouse.o pckbd.o vga.o
 endif
 
+OUTPUT_NAME=temu$(EXE)
+
 temu$(EXE): $(EMU_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $^ $(EMU_LIBS)
+	$(CC) $(LDFLAGS) -o $(OUTPUT_NAME) $^ $(EMU_LIBS)
 
 riscv_cpu32.o: riscv_cpu.c
 	$(CC) $(CFLAGS) -DMAX_XLEN=32 -c -o $@ $<


### PR DESCRIPTION
Now files generated by emscripten can be named via "--build-arg JS_OUTPUT_NAME".