### PR TITLE
deps: updates wazero to 1.0.0-rc.2

### DIFF
--- a/tests/wazero/go.mod
+++ b/tests/wazero/go.mod
@@ -2,4 +2,4 @@ module github.com/ktock/container2wasm/examples/wazero
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.0.0-pre.8
+require github.com/tetratelabs/wazero v1.0.0-rc.2

--- a/tests/wazero/go.sum
+++ b/tests/wazero/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
-github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-rc.2 h1:OA3UUynnoqxrjCQ94mpAtdO4/oMxFQVNL2BXDMOc66Q=
+github.com/tetratelabs/wazero v1.0.0-rc.2/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-rc.2](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-rc.2) which notably
* is the final release candidate before 1.0 next Friday.
* improves instantiation performance (startup time)
* passes `os` package tests defined by Go.
* no longer supports importing unnamed modules.