### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The following shows the techniqual details:
 
 ## Similar projects
 
-There are several container runtimes support running WASM applications but they don't run containers on WASM.
+There are several container runtimes support running WASM applications, but they don't run containers on WASM.
 
 - WASM on container runtimes
   - Docker+Wasm integration: https://docs.docker.com/desktop/wasm/
@@ -200,7 +200,7 @@ There are several container runtimes support running WASM applications but they 
   - crun: https://github.com/containers/crun
   - krustlet: https://github.com/krustlet/krustlet
 
-There are emulators that support running linux on WASM but they don't support WASI.
+There are emulators that support running linux on WASM, but they don't support WASI.
 
 - x86 on WASM
   - v86: https://github.com/copy/v86
@@ -210,7 +210,7 @@ There are emulators that support running linux on WASM but they don't support WA
 
 ## Additional Documents
 
-- [`./examples/`](./examples/): Examples (python, php, non-riscv64 image, etc.)
+- [`./examples/`](./examples): Examples (python, php, non-riscv64 image, etc.)
 
 ## Acknowledgement
 

--- a/tests/wazero/go.mod
+++ b/tests/wazero/go.mod
@@ -2,4 +2,4 @@ module github.com/ktock/container2wasm/examples/wazero
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.0.0-rc.2
+require github.com/tetratelabs/wazero v1.0.1

--- a/tests/wazero/go.sum
+++ b/tests/wazero/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-rc.2 h1:OA3UUynnoqxrjCQ94mpAtdO4/oMxFQVNL2BXDMOc66Q=
-github.com/tetratelabs/wazero v1.0.0-rc.2/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/tests/wazero/main.go
+++ b/tests/wazero/main.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
-	"github.com/tetratelabs/wazero/sys"
 )
 
 func main() {
@@ -48,9 +47,6 @@ func main() {
 	_, err = r.InstantiateModule(ctx, compiled,
 		wazero.NewModuleConfig().WithSysWalltime().WithSysNanotime().WithSysNanosleep().WithRandSource(crand.Reader).WithStdout(os.Stdout).WithStderr(os.Stderr).WithStdin(newNonBlockReader(os.Stdin)).WithFSConfig(fsConfig).WithArgs(append([]string{"arg0"}, args[1:]...)...))
 	if err != nil {
-		if exitErr, ok := err.(*sys.ExitError); ok && exitErr.ExitCode() == 0 {
-			return
-		}
 		panic(err)
 	}
 	return


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatibility promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.

Finally, if you would like to share your work, feel free to update our [users page](https://github.com/tetratelabs/wazero/blob/main/site/content/community/users.md)!