### PR TITLE
deps: updates wazero to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The following shows the techniqual details:
 |---|---|---|---|
 |wasmtime|:heavy_check_mark:|:heavy_check_mark:||
 |wamr(wasm-micro-runtime)|:heavy_check_mark:|:heavy_check_mark:||
-|wazero|:construction: (stdin unsupported)|:heavy_check_mark:|non-blocking stdin doesn't seem to work|
+|wazero|:heavy_check_mark:|:heavy_check_mark:||
 |wasmer|:construction: (stdin unsupported)|:heavy_check_mark:|non-blocking stdin doesn't seem to work|
 |wasmedge|:construction: (stdin unsupported)|:heavy_check_mark:|non-blocking stdin doesn't seem to work|
 

--- a/tests/wazero/go.mod
+++ b/tests/wazero/go.mod
@@ -2,4 +2,4 @@ module github.com/ktock/container2wasm/examples/wazero
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.0.1
+require github.com/tetratelabs/wazero v1.0.2

--- a/tests/wazero/go.sum
+++ b/tests/wazero/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
-github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.0.2 h1:lpwL5zczFHk2mxKur98035Gig+Z3vd9JURk6lUdZxXY=
+github.com/tetratelabs/wazero v1.0.2/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.2](https://github.com/tetratelabs/wazero/releases/tag/v1.0.2) which improves compiler performance, supports non-blocking stdin, and fixes some glitches.