### PR TITLE
Prepare for v0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG OPTIMIZATION_MODE=wizer # "wizer" or "native"
 # ARG OPTIMIZATION_MODE=native
 
 ARG SOURCE_REPO=https://github.com/ktock/container2wasm
-ARG SOURCE_REPO_VERSION=v0.2.3
+ARG SOURCE_REPO_VERSION=v0.3.0
 
 FROM scratch AS oci-image-src
 COPY . .

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,7 +3,7 @@
 set -eu -o pipefail
 
 CONTAINER=test-container
-TIMEOUT=50m
+TIMEOUT=80m
 
 DOCKER_BUILDKIT=1 docker build --progress=plain -f Dockerfile.test -t $CONTAINER .
 docker run --rm -d --privileged -v ${CONTAINER}-cache:/var/lib/docker --name $CONTAINER $CONTAINER


### PR DESCRIPTION
```
- Improved support for running x86_64 containers on WASI/browser (#59)
- Added example of WASI-on-browser (#59)
- Removed hack for `poll_oneoff` leveraging wasi-vfs 0.3.0 (#54), thanks to @kateinoigakukun
- Refactored wazero tests and updated wazero version (#23, #28), thanks to @codefromthecrypt
```