### PR TITLE
Prepare for v0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG OPTIMIZATION_MODE=wizer # "wizer" or "native"
 # ARG OPTIMIZATION_MODE=native
 
 ARG SOURCE_REPO=https://github.com/ktock/container2wasm
-ARG SOURCE_REPO_VERSION=v0.3.0
+ARG SOURCE_REPO_VERSION=v0.4.0
 
 FROM scratch AS oci-image-src
 COPY . .


### PR DESCRIPTION
```
## Notable Changes

- x86: support mapdir on wasi (#98)
- Fixed Dockerfile not to case cache miss when building a Wasm image with a custom name (#73)
```