### PR TITLE
Do not mount tmpfs on /run

### DIFF
--- a/cmd/create-spec/main.go
+++ b/cmd/create-spec/main.go
@@ -245,6 +245,7 @@ func generateSpec(config spec.Image, rootfs string) (_ *specs.Spec, err error) {
 	}
 	s, err := ctdoci.GenerateSpecWithPlatform(ctdCtx, nil, p, &ctdcontainers.Container{},
 		ctdoci.WithHostNamespace(specs.NetworkNamespace),
+		ctdoci.WithoutRunMount,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate spec: %w", err)


### PR DESCRIPTION
#131 (`Failed to run frr with wasmtime: Can't create pid lock file /var/run/frr/watchfrr.pid (No such file or directory), exiting`)