### PR TITLE
ci: release: migrate from hub to gh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,6 @@ jobs:
         MINIMAL_TAR=$(ls -1 ${OUTPUT_DIR} | grep container2wasm-v | head -1)
         MINIMAL_TAR_LIST=$(tar --list -vvf ${OUTPUT_DIR}/${MINIMAL_TAR})
         cat <<EOF > ${GITHUB_WORKSPACE}/release-note.txt
-        ${RELEASE_TAG}
-
         (TBD)
 
         ## About the tarball binaries
@@ -67,9 +65,5 @@ jobs:
         The sha256sum of SHA256SUMS is \`${SHA256SUM_OF_SHA256SUMS}\`
 
         EOF
-        ASSET_FLAGS=()
         ls -al ${OUTPUT_DIR}/
-        for F in ${OUTPUT_DIR}/* ; do
-          ASSET_FLAGS+=("-a" "$F")
-        done
-        hub release create "${ASSET_FLAGS[@]}" -F ${GITHUB_WORKSPACE}/release-note.txt --draft "${RELEASE_TAG}"
+        gh release create -F ${GITHUB_WORKSPACE}/release-note.txt --draft --title "${RELEASE_TAG}" "${RELEASE_TAG}" ${OUTPUT_DIR}/*


### PR DESCRIPTION
`hub` has been deprecated: https://github.com/actions/runner-images/issues/8362