### PR TITLE
c2w: specify build platform

### DIFF
--- a/cmd/c2w-net/main.go
+++ b/cmd/c2w-net/main.go
@@ -76,7 +76,7 @@ func main() {
 	if *invoke {
 		go func() {
 			var conn net.Conn
-			for i := 0; i < 5; i++ {
+			for i := 0; i < 10; i++ {
 				time.Sleep(1 * time.Second)
 				fmt.Fprintf(os.Stderr, "connecting to NW...\n")
 				conn, err = net.Dial("tcp", *wasiAddr)

--- a/cmd/c2w/main.go
+++ b/cmd/c2w/main.go
@@ -139,6 +139,7 @@ func build(builderPath string, srcImgName string, destDir, destFile string, clic
 		"buildx", "build", "--progress=plain",
 		"--build-arg", fmt.Sprintf("TARGETARCH=%s", clicontext.String("target-arch")),
 		"--build-arg", fmt.Sprintf("TARGETPLATFORM=linux/%s", clicontext.String("target-arch")),
+		"--platform=linux/amd64",
 	}
 	var dockerfilePath string
 	if o := clicontext.String("dockerfile"); o != "" {
@@ -204,6 +205,7 @@ func buildWithLegacyBuilder(builderPath string, srcImgName, destDir, destFile st
 
 	buildArgs := []string{
 		"build", "--progress=plain",
+		"--platform=linux/amd64",
 		"--build-arg", fmt.Sprintf("TARGETARCH=%s", clicontext.String("target-arch")),
 	}
 	var dockerfilePath string


### PR DESCRIPTION
Fix: #155

Always specify platform flag to make the build run based on amd64 images.
Ideally we should support performing build on arm64,etc images but as of now wasi-sdk only supports amd64 linux only.