### PR TITLE
Prepare for v0.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG OPTIMIZATION_MODE=wizer # "wizer" or "native"
 # ARG OPTIMIZATION_MODE=native
 
 ARG SOURCE_REPO=https://github.com/ktock/container2wasm
-ARG SOURCE_REPO_VERSION=v0.5.1
+ARG SOURCE_REPO_VERSION=v0.5.2
 
 FROM scratch AS oci-image-src
 COPY . .


### PR DESCRIPTION
```
## Notable Changes

- Add default `TERM=xterm` envvar (#148)
- c2w: Always specify platform flag to run the build based on amd64 images (#160)
```