### PR TITLE
Prepare for v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG OPTIMIZATION_MODE=wizer # "wizer" or "native"
 # ARG OPTIMIZATION_MODE=native
 
 ARG SOURCE_REPO=https://github.com/ktock/container2wasm
-ARG SOURCE_REPO_VERSION=v0.5.3
+ARG SOURCE_REPO_VERSION=v0.6.0
 
 FROM scratch AS oci-image-src
 COPY . .


### PR DESCRIPTION
```
## Notable Changes

- Enabled to fetch and run container images on browser, without pre-conversion of the images (#200)
- Fixed `c2w-net` to use new wasmtime CLI syntax of wamstime >= 14 (#194)
```