### PR TITLE
Prepare for 0.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG OPTIMIZATION_MODE=wizer # "wizer" or "native"
 # ARG OPTIMIZATION_MODE=native
 
 ARG SOURCE_REPO=https://github.com/ktock/container2wasm
-ARG SOURCE_REPO_VERSION=v0.6.1
+ARG SOURCE_REPO_VERSION=v0.6.2
 
 FROM scratch AS oci-image-src
 COPY . .


### PR DESCRIPTION
```
## Notable Changes

- Fixed error on conversion of images containing non-container manifest (#212)
```