### PR TITLE
Allow new privileges in container

### DIFF
--- a/cmd/create-spec/main.go
+++ b/cmd/create-spec/main.go
@@ -323,7 +323,8 @@ func generateSpec(config spec.Image, rootfs string) (_ *specs.Spec, err error) {
 		ctdoci.WithHostNamespace(specs.NetworkNamespace),
 		ctdoci.WithoutRunMount,
 		ctdoci.WithEnv(ic.Env),
-		ctdoci.WithTTY, // TODO: make it configurable
+		ctdoci.WithTTY,           // TODO: make it configurable
+		ctdoci.WithNewPrivileges, // TODO: make it configurable
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate spec: %w", err)


### PR DESCRIPTION
Fixes #222

This is needed to run sudo in container. In the future we can make it configurable like [Docker can](https://github.com/docker/cli/blob/297704984b5334eac3311c30c36133b8b22bda6a/man/docker-run.1.md?plain=1#L615).