### PR TITLE
imagemounter: Decompress layers in JS wrapper

### DIFF
--- a/extras/imagemounter/go.mod
+++ b/extras/imagemounter/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/opencontainers/runc v1.1.5
 	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/sirupsen/logrus v1.9.3
-	golang.org/x/sync v0.4.0
+	golang.org/x/sync v0.6.0
 )
 
 require (
@@ -37,7 +37,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/insomniacslk/dhcp v0.0.0-20220504074936-1ca156eafb9f // indirect
-	github.com/klauspost/compress v1.17.2 // indirect
+	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/miekg/dns v1.1.55 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
@@ -70,6 +70,8 @@ replace github.com/u-root/uio => github.com/ktock/u-root-uio v0.0.0-202309111429
 
 replace github.com/hugelgupf/p9 => github.com/ktock/p9 v0.0.0-20240109162600-dac0f97fe886
 
-replace github.com/containerd/stargz-snapshotter => github.com/ktock/stargz-snapshotter v0.0.1-0.20240109162903-e5206b85e4cc
+replace github.com/containerd/stargz-snapshotter => github.com/ktock/stargz-snapshotter v0.0.1-0.20240304123548-c3fcce188d68
 
 replace github.com/containerd/containerd => github.com/ktock/containerd v1.2.1-0.20240109162750-28ec64e033db
+
+replace github.com/containerd/stargz-snapshotter/estargz => github.com/ktock/stargz-snapshotter/estargz v0.0.0-20240304123548-c3fcce188d68

--- a/extras/imagemounter/go.sum
+++ b/extras/imagemounter/go.sum
@@ -29,8 +29,6 @@ github.com/containerd/continuity v0.4.3 h1:6HVkalIp+2u1ZLH1J/pYX2oBVXlJZvh1X1A7b
 github.com/containerd/continuity v0.4.3/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
-github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G/ZW/0kEe2oEKCdS/ZxIyoCU=
-github.com/containerd/stargz-snapshotter/estargz v0.15.1/go.mod h1:gr2RNwukQ/S9Nv33Lt6UC7xEx58C+LHRdoqbEKjz1Kk=
 github.com/containerd/ttrpc v1.2.2 h1:9vqZr0pxwOF5koz6N0N3kJ0zDHokrcPxIR/ZR2YFtOs=
 github.com/containerd/ttrpc v1.2.2/go.mod h1:sIT6l32Ph/H9cvnJsfXM5drIVzTr5A2flTf1G5tYZak=
 github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4=
@@ -146,8 +144,8 @@ github.com/kaey/framebuffer v0.0.0-20140402104929-7b385489a1ff/go.mod h1:tS4qtlc
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.10.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.17.2 h1:RlWWUY/Dr4fL8qk9YG7DTZ7PDgME2V4csBXA8L/ixi4=
-github.com/klauspost/compress v1.17.2/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/compress v1.17.7 h1:ehO88t2UGzQK66LMdE8tibEd1ErmzZjNEqWkjLAKQQg=
+github.com/klauspost/compress v1.17.7/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -160,8 +158,10 @@ github.com/ktock/insomniacslk-dhcp v0.0.0-20230911142651-b86573a014b1 h1:KD92SLh
 github.com/ktock/insomniacslk-dhcp v0.0.0-20230911142651-b86573a014b1/go.mod h1:h+MxyHxRg9NH3terB1nfRIUaQEcI0XOVkdR9LNBlp8E=
 github.com/ktock/p9 v0.0.0-20240109162600-dac0f97fe886 h1:w26G030q4XUqgRPaGfQcyFi1a5R4Nt9VC+6P07c7CrU=
 github.com/ktock/p9 v0.0.0-20240109162600-dac0f97fe886/go.mod h1:d5H7Bc5VS6NgKyPmAGLB6qMj5rvRpP/u0HaVI5pp7kY=
-github.com/ktock/stargz-snapshotter v0.0.1-0.20240109162903-e5206b85e4cc h1:EXrPMV/2hLjwbJMTVSM1y6a/AnPxLLD5sXEY7R832zE=
-github.com/ktock/stargz-snapshotter v0.0.1-0.20240109162903-e5206b85e4cc/go.mod h1:74D+J1m1RMXytLmWxegXWhtOSRHPWZKpKc2NdK3S+us=
+github.com/ktock/stargz-snapshotter v0.0.1-0.20240304123548-c3fcce188d68 h1:qzxytQYHEjdoqEMcAvZGAZCiy78zhGT5K+5afuX8/Uo=
+github.com/ktock/stargz-snapshotter v0.0.1-0.20240304123548-c3fcce188d68/go.mod h1:74D+J1m1RMXytLmWxegXWhtOSRHPWZKpKc2NdK3S+us=
+github.com/ktock/stargz-snapshotter/estargz v0.0.0-20240304123548-c3fcce188d68 h1:WwJnVlL+6g3VF+NNluCrAy2BRiMLwEJH4SMqDrbKxMc=
+github.com/ktock/stargz-snapshotter/estargz v0.0.0-20240304123548-c3fcce188d68/go.mod h1:gr2RNwukQ/S9Nv33Lt6UC7xEx58C+LHRdoqbEKjz1Kk=
 github.com/ktock/u-root-uio v0.0.0-20230911142931-5cf720bc8a29 h1:BNd7VYl9yNjxsA4Bt9YKAyKJKIymo1v9f7M2cWhh9iU=
 github.com/ktock/u-root-uio v0.0.0-20230911142931-5cf720bc8a29/go.mod h1:LpEX5FO/cB+WF4TYGY1V5qktpaZLkKkSegbr0V4eYXA=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -332,8 +332,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
-golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/extras/runcontainerjs/src/web/stack-worker.js
+++ b/extras/runcontainerjs/src/web/stack-worker.js
@@ -158,6 +158,73 @@ function wasiHack(wasi, certfd, connfd) {
 
 function envHack(wasi){
     return {
+        decompress_init: function(idP) {
+            if (idP < 0) {
+                idP = idP >>> 0;
+            }
+            var buffer = new DataView(wasi.inst.exports.memory.buffer);
+            var buffer8 = new Uint8Array(wasi.inst.exports.memory.buffer);
+
+            streamCtrl[0] = 0;
+            postMessage({
+                type: "decompress_init",
+            });
+            Atomics.wait(streamCtrl, 0, 0);
+            if (streamStatus[0] < 0) {
+                return ERRNO_INVAL;
+            }
+            var id = streamStatus[0];
+            buffer.setUint32(idP, id, true);
+            return 0;
+        },
+        decompress_write: function(id, bufP, buflen, isEOF) {
+            if (bufP < 0) {
+                bufP = bufP >>> 0;
+            }
+            var buf = new Uint8Array(wasi.inst.exports.memory.buffer, bufP, buflen);
+            streamCtrl[0] = 0;
+            postMessage({
+                type: "decompress_write",
+                id: id,
+                chunk: buf.slice(0, buf.length),
+                isEOF: isEOF,
+            });
+            Atomics.wait(streamCtrl, 0, 0);
+            if (streamStatus[0] < 0) {
+                return ERRNO_INVAL;
+            }
+            return 0;
+        },
+        decompress_read: function(id, bufP, buflen, recvLenP, isEOFP) {
+            if (bufP < 0) {
+                bufP = bufP >>> 0;
+            }
+            if (recvLenP < 0) {
+                recvLenP = recvLenP >>> 0;
+            }
+            if (isEOFP < 0) {
+                isEOFP = isEOFP >>> 0;
+            }
+            var buffer = new DataView(wasi.inst.exports.memory.buffer);
+            var buffer8 = new Uint8Array(wasi.inst.exports.memory.buffer);
+
+            streamCtrl[0] = 0;
+            postMessage({type: "decompress_read", id: id, len: buflen});
+            Atomics.wait(streamCtrl, 0, 0);
+            if (streamStatus[0] < 0) {
+                return ERRNO_INVAL;
+            }
+            var ddlen = streamLen[0];
+            var res = streamData.subarray(0, ddlen);
+            buffer8.set(res, bufP);
+            buffer.setUint32(recvLenP, ddlen, true);
+            if (streamStatus[0] == 1) {
+                buffer.setUint32(isEOFP, 1, true);
+            } else {
+                buffer.setUint32(isEOFP, 0, true);
+            }
+            return 0;
+        },
         http_send: function(addressP, addresslen, reqP, reqlen, idP){
             var buffer = new DataView(wasi.inst.exports.memory.buffer);
             var address = new Uint8Array(wasi.inst.exports.memory.buffer, addressP, addresslen);


### PR DESCRIPTION
Performing gzip decompression in wasm looks very slow (56s for starting gcc:9.2.0 on chrome) and offloading it to JS seems to speed up this (15s for the same image on chrome).