### PR TITLE
mapdir: use EOPNOTSUPP for xattr

### DIFF
--- a/patches/bochs/Bochs/bochs/wasm.cc
+++ b/patches/bochs/Bochs/bochs/wasm.cc
@@ -531,6 +531,7 @@ static int errno_table[][2] = {
     { P9_ENOSPC, ENOSPC },
     { P9_ENOTEMPTY, ENOTEMPTY },
     { P9_EPROTO, EPROTO },
+    { P9_EOPNOTSUPP, EOPNOTSUPP },
     { P9_ENOTSUP, ENOTSUP },
 };
 
@@ -2413,7 +2414,7 @@ int bx_virtio_9p_ctrl_c::device_recv(int queue_idx, int desc_idx, int read_size,
     case 30: /* xattrwalk */
         {
             /* not supported yet */
-            err = -P9_ENOTSUP;
+            err = -P9_EOPNOTSUPP;
             goto error;
         }
         break;

--- a/patches/bochs/Bochs/bochs/wasm.h
+++ b/patches/bochs/Bochs/bochs/wasm.h
@@ -450,16 +450,17 @@ private:
 #define P9_SETATTR_ATIME_SET 0x00000080
 #define P9_SETATTR_MTIME_SET 0x00000100
 
-#define P9_EPERM     1
-#define P9_ENOENT    2
-#define P9_EIO       5
-#define	P9_EEXIST    17
-#define	P9_ENOTDIR   20
-#define P9_EINVAL    22
-#define	P9_ENOSPC    28
-#define P9_ENOTEMPTY 39
-#define P9_EPROTO    71
-#define P9_ENOTSUP   524
+#define P9_EPERM      1
+#define P9_ENOENT     2
+#define P9_EIO        5
+#define P9_EEXIST     17
+#define P9_ENOTDIR    20
+#define P9_EINVAL     22
+#define P9_ENOSPC     28
+#define P9_ENOTEMPTY  39
+#define P9_EPROTO     71
+#define P9_EOPNOTSUPP 95
+#define P9_ENOTSUP    524
 
 typedef struct VIRTIO9PDevice {
     FSDevice *fs;

--- a/patches/tinyemu/tinyemu/fs.h
+++ b/patches/tinyemu/tinyemu/fs.h
@@ -80,16 +80,17 @@
 #define P9_SETATTR_ATIME_SET 0x00000080
 #define P9_SETATTR_MTIME_SET 0x00000100
 
-#define P9_EPERM     1
-#define P9_ENOENT    2
-#define P9_EIO       5
-#define	P9_EEXIST    17
-#define	P9_ENOTDIR   20
-#define P9_EINVAL    22
-#define	P9_ENOSPC    28
-#define P9_ENOTEMPTY 39
-#define P9_EPROTO    71
-#define P9_ENOTSUP   524
+#define P9_EPERM      1
+#define P9_ENOENT     2
+#define P9_EIO        5
+#define P9_EEXIST     17
+#define P9_ENOTDIR    20
+#define P9_EINVAL     22
+#define P9_ENOSPC     28
+#define P9_ENOTEMPTY  39
+#define P9_EPROTO     71
+#define P9_EOPNOTSUPP 95
+#define P9_ENOTSUP    524
 
 typedef struct FSDevice FSDevice;
 typedef struct FSFile FSFile;

--- a/patches/tinyemu/tinyemu/fs_disk.c
+++ b/patches/tinyemu/tinyemu/fs_disk.c
@@ -90,6 +90,7 @@ static int errno_table[][2] = {
     { P9_ENOSPC, ENOSPC },
     { P9_ENOTEMPTY, ENOTEMPTY },
     { P9_EPROTO, EPROTO },
+    { P9_EOPNOTSUPP, EOPNOTSUPP },
     { P9_ENOTSUP, ENOTSUP },
 };
 

--- a/patches/tinyemu/tinyemu/virtio.c
+++ b/patches/tinyemu/tinyemu/virtio.c
@@ -2276,7 +2276,7 @@ static int virtio_9p_recv_request(VIRTIODevice *s1, int queue_idx,
     case 30: /* xattrwalk */
         {
             /* not supported yet */
-            err = -P9_ENOTSUP;
+            err = -P9_EOPNOTSUPP;
             goto error;
         }
         break;


### PR DESCRIPTION
Currently (unimplemented) 9pfs's xattr returns ENOTSUP but `ls` (GNU coreutils) prints error message for this errno. This commit fixes this by using EOPNOTSUPP instead, for supressing the error message.
```
$ wasmtime --mapdir /test/dir/share::/tmp/share/ /app/out.wasm ls -al /test/dir/share/
ls: /test/dir/share/: Unknown error 524
ls: /test/dir/share/.: Unknown error 524
ls: /test/dir/share/a: Unknown error 524
total 0
d--------- 1 root root  0 Jan  1  1970 .
drwxr-xr-x 3 root root 60 Mar  7 09:45 ..
---------- 1 root root  3 Mar  7 09:05 a
```
