### PR TITLE
Prepare for v0.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG OPTIMIZATION_MODE=wizer # "wizer" or "native"
 # ARG OPTIMIZATION_MODE=native
 
 ARG SOURCE_REPO=https://github.com/ktock/container2wasm
-ARG SOURCE_REPO_VERSION=v0.6.2
+ARG SOURCE_REPO_VERSION=v0.6.3
 
 FROM scratch AS oci-image-src
 COPY . .


### PR DESCRIPTION
```
## Notable Changes

- Fixed error printed by `ls` for accessing xattr (#245)
- Fixed `sudo` didn't work in container (#225)
- Fixed imagemounter to decompress layers in JS wrapper (#244)
- Fixed fd error on operations for mapped directories (#242)
```