### PR TITLE
Use pre-configured cpu model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -470,7 +470,7 @@ RUN LOGGING_FLAG=--disable-logging && \
     CXXFLAGS="${CFLAGS}" \
     ./configure --host wasm32-unknown-wasi --enable-x86-64 --with-nogui --enable-usb --enable-usb-ehci \
     --disable-large-ramfile --disable-show-ips --disable-stats ${LOGGING_FLAG} \
-    --enable-repeat-speedups --enable-fast-function-calls --disable-trace-linking --enable-handlers-chaining # TODO: --enable-trace-linking causes "out of bounds memory access"
+    --enable-repeat-speedups --enable-fast-function-calls --disable-trace-linking --enable-handlers-chaining --enable-avx # TODO: --enable-trace-linking causes "out of bounds memory access"
 RUN make -j$(nproc) bochs EMU_DEPS="/tools/wasi-vfs/libwasi_vfs.a /jmp/jmp /vfs/vfs.o -lrt"
 RUN /binaryen/binaryen-version_${BINARYEN_VERSION}/bin/wasm-opt bochs --asyncify -O2 -o bochs.async --pass-arg=asyncify-ignore-imports
 RUN mv bochs.async bochs
@@ -504,7 +504,7 @@ RUN LOGGING_FLAG=--disable-logging && \
     CXXFLAGS="${CFLAGS}" \
     emconfigure ./configure --host wasm32-unknown-emscripten --enable-x86-64 --with-nogui --enable-usb --enable-usb-ehci \
     --disable-large-ramfile --disable-show-ips --disable-stats ${LOGGING_FLAG} \
-    --enable-repeat-speedups --enable-fast-function-calls --disable-trace-linking --enable-handlers-chaining # TODO: --enable-trace-linking causes "too much recursion"
+    --enable-repeat-speedups --enable-fast-function-calls --disable-trace-linking --enable-handlers-chaining --enable-avx # TODO: --enable-trace-linking causes "too much recursion"
 RUN emmake make -j$(nproc) bochs EMU_DEPS="--preload-file /pack"
 RUN mkdir -p /out/ && mv bochs /out/out.js && mv bochs.wasm /out/ && mv bochs.data /out/
 

--- a/patches/bochs/Bochs/bochs/cpu/msr.cc
+++ b/patches/bochs/Bochs/bochs/cpu/msr.cc
@@ -464,7 +464,7 @@ bool BX_CPP_AttrRegparmN(2) BX_CPU_C::handle_unknown_rdmsr(Bit32u index, Bit64u 
 #endif
     {
       // failed to find the MSR, could #GP or ignore it silently
-      BX_ERROR(("RDMSR: Unknown register %#x", index));
+      BX_DEBUG(("RDMSR: Unknown register %#x", index));
 
       if (! BX_CPU_THIS_PTR ignore_bad_msrs)
         return 0; // will result in #GP fault due to unknown MSR

--- a/patches/bochs/bochsrc.template
+++ b/patches/bochs/bochsrc.template
@@ -6,7 +6,7 @@ ata0-master: type=cdrom, path="/pack/boot.iso", status=inserted
 usb_ehci: port1=cdrom, options1="path:/pack/rootfs.bin, speed:high"
 boot: cdrom
 mouse: enabled=0
-cpu: ips=40000000
+cpu: ips=40000000, model=corei7_haswell_4770
 clock: sync=both, rtc_sync=1, time0=local
 display_library: nogui
 vga: extension=none, realtime=0, update_freq=1, ddc=disabled


### PR DESCRIPTION
 This enables to run applications depend on recent features.